### PR TITLE
Handle grouping in ProjectedQuery

### DIFF
--- a/PersistDB.xcodeproj/project.pbxproj
+++ b/PersistDB.xcodeproj/project.pbxproj
@@ -61,6 +61,8 @@
 		BEBC36D4200F98FC000E3AAB /* ResultSetTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = BEBC36D3200F98FC000E3AAB /* ResultSetTests.swift */; };
 		BEBC36DA2013C0D9000E3AAB /* Differ.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = BEBC36DB2013C0D9000E3AAB /* Differ.framework */; };
 		BEBEB06D1EBEADAA00522152 /* Store.swift in Sources */ = {isa = PBXBuildFile; fileRef = BEBEB06C1EBEADAA00522152 /* Store.swift */; };
+		BEC073ED201D05F800D43F12 /* Swift.swift in Sources */ = {isa = PBXBuildFile; fileRef = BEC073EC201D05F800D43F12 /* Swift.swift */; };
+		BEC073EE201D05F800D43F12 /* Swift.swift in Sources */ = {isa = PBXBuildFile; fileRef = BEC073EC201D05F800D43F12 /* Swift.swift */; };
 		BEC1C2411F1DA64400D29EFF /* SchemataTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = BEC1C2401F1DA64400D29EFF /* SchemataTests.swift */; };
 		BECF33931EEBA6A600F9FC88 /* Model.swift in Sources */ = {isa = PBXBuildFile; fileRef = BECF33921EEBA6A600F9FC88 /* Model.swift */; };
 		BECF33961EEBA6BF00F9FC88 /* ModelTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = BECF33941EEBA6BA00F9FC88 /* ModelTests.swift */; };
@@ -206,6 +208,7 @@
 		BEBC36D7201246C1000E3AAB /* Table.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Table.swift; sourceTree = "<group>"; };
 		BEBC36DB2013C0D9000E3AAB /* Differ.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; path = Differ.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		BEBEB06C1EBEADAA00522152 /* Store.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Store.swift; sourceTree = "<group>"; };
+		BEC073EC201D05F800D43F12 /* Swift.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Swift.swift; sourceTree = "<group>"; };
 		BEC1C2401F1DA64400D29EFF /* SchemataTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SchemataTests.swift; sourceTree = "<group>"; };
 		BECF33921EEBA6A600F9FC88 /* Model.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Model.swift; sourceTree = "<group>"; };
 		BECF33941EEBA6BA00F9FC88 /* ModelTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ModelTests.swift; sourceTree = "<group>"; };
@@ -400,6 +403,7 @@
 			children = (
 				BEBC36CA200E8FA6000E3AAB /* ReactiveSwift.swift */,
 				BEBC36CC200E8FD8000E3AAB /* Schemata.swift */,
+				BEC073EC201D05F800D43F12 /* Swift.swift */,
 			);
 			path = Extensions;
 			sourceTree = "<group>";
@@ -674,6 +678,7 @@
 				BE1B3E6D1FF03551001620A9 /* SQL.Action.swift in Sources */,
 				BE7740EB1EFFDC5500D1F5A5 /* SQL.Ordering.swift in Sources */,
 				BEDE90CA2016259F004656FC /* Table.swift in Sources */,
+				BEC073ED201D05F800D43F12 /* Swift.swift in Sources */,
 				BE7740EC1EFFDC5500D1F5A5 /* SQL.swift in Sources */,
 				BE10ED7E1FE60267008FFE25 /* SQL.Delete.swift in Sources */,
 				BEBEB06D1EBEADAA00522152 /* Store.swift in Sources */,
@@ -739,6 +744,7 @@
 				BEDE90B5201605AE004656FC /* TestStore.swift in Sources */,
 				BEDE90A8201605AE004656FC /* SQL.swift in Sources */,
 				BEDE90CB201625A0004656FC /* Table.swift in Sources */,
+				BEC073EE201D05F800D43F12 /* Swift.swift in Sources */,
 				BEDE90B6201605AE004656FC /* Update.swift in Sources */,
 				BEDE90B1201605AE004656FC /* ProjectedQuery.swift in Sources */,
 				BEDE909A201605AE004656FC /* ReactiveSwift.swift in Sources */,

--- a/Source/Extensions/ReactiveSwift.swift
+++ b/Source/Extensions/ReactiveSwift.swift
@@ -45,18 +45,4 @@ extension SignalProducer {
 
         return result
     }
-
-    internal func collect<Key: Equatable>(
-        groupingBy: @escaping (Value) -> Key
-    ) -> SignalProducer<(Key, [Value]), Error> {
-        return map { (groupingBy($0), $0) }
-            .collect { values, value in
-                guard let key = values.first?.0 else { return false }
-                return key != value.0
-            }
-            .filterMap { tuples in
-                guard let key = tuples.first?.0 else { return nil }
-                return (key, tuples.map { $0.1 })
-            }
-    }
 }

--- a/Source/Extensions/Swift.swift
+++ b/Source/Extensions/Swift.swift
@@ -1,0 +1,23 @@
+extension Collection {
+    internal func group<Key, Value>(
+        _ block: @escaping (Element) -> (Key, Value)
+    ) -> [Group<Key, Value>] {
+        let tuples = map(block)
+        guard let first = tuples.first else { return [] }
+
+        var result: [Group<Key, Value>] = []
+
+        var group = Group(key: first.0, values: [ first.1 ])
+        for (key, value) in tuples.dropFirst() {
+            if key == group.key {
+                group.values.append(value)
+            } else {
+                result.append(group)
+                group = Group(key: key, values: [ value ])
+            }
+        }
+        result.append(group)
+
+        return result
+    }
+}

--- a/Source/Group.swift
+++ b/Source/Group.swift
@@ -4,7 +4,7 @@ public struct Group<Key: Hashable, Value: Hashable> {
     public let key: Key
 
     /// The values in this group.
-    public let values: [Value]
+    public var values: [Value]
 
     public init(key: Key, values: [Value]) {
         self.key = key

--- a/Source/ProjectedQuery.swift
+++ b/Source/ProjectedQuery.swift
@@ -1,34 +1,72 @@
 import Foundation
+import Schemata
 
-internal struct ProjectedQuery<Projection: ModelProjection> {
+internal struct ProjectedQuery<Group: ModelValue, Projection: PersistDB.ModelProjection> {
     let sql: SQL.Query
-    let keyPaths: [String: PartialKeyPath<Projection.Model>]
+    let keyPaths: [UUID: PartialKeyPath<Projection.Model>]
 
-    init(_ query: Query<Projection.Model>) {
+    fileprivate init(_ sql: SQL.Query) {
         let projection = Projection.projection
-        let sql = query.makeSQL()
 
         keyPaths = Dictionary(uniqueKeysWithValues: projection.keyPaths.map { keyPath in
-            (UUID().uuidString, keyPath)
+            (UUID(), keyPath)
         })
 
         let aliases = Dictionary(uniqueKeysWithValues: keyPaths.map { ($1, $0) })
         let results = projection.keyPaths.map { keyPath -> SQL.Result in
             let sql = AnyExpression(keyPath).makeSQL()
-            return SQL.Result(sql, alias: aliases[keyPath])
+            return SQL.Result(sql, alias: aliases[keyPath]?.uuidString)
         }
 
         self.sql = SQL.Query(
-            results: results,
+            results: sql.results + results,
             predicates: sql.predicates,
             order: sql.order
         )
     }
 
+    func resultSet(for rows: [Row]) -> ResultSet<Group, Projection> {
+        let projection = Projection.projection
+        let groups = rows
+            .flatMap { row -> (Group, Projection)? in
+                return projection
+                    .makeValue(values(for: row))
+                    .map { value in
+                        let groupBy: Group
+                        if Group.self == None.self {
+                            groupBy = None.none as! Group // swiftlint:disable:this force_cast
+                        } else {
+                            groupBy = Group.decode(row.dictionary["groupBy"]!)!
+                                as! Group // swiftlint:disable:this force_cast
+                        }
+                        return (groupBy, value)
+                    }
+            }
+            .group { return $0 }
+        return ResultSet(groups)
+    }
+
     func values(for row: Row) -> [PartialKeyPath<Projection.Model>: SQL.Value] {
         return Dictionary(uniqueKeysWithValues: row.dictionary.flatMap { alias, value in
-            guard let keyPath = keyPaths[alias] else { return nil }
+            guard let uuid = UUID(uuidString: alias), let keyPath = keyPaths[uuid] else {
+                return nil
+            }
             return (keyPath, value)
         })
+    }
+}
+
+extension ProjectedQuery where Group == None {
+    init(_ query: Query<Projection.Model>) {
+        self.init(query.makeSQL())
+    }
+}
+
+extension ProjectedQuery {
+    init(_ query: Query<Projection.Model>, groupedBy: SQL.Ordering) {
+        let sql = query.makeSQL()
+            .select(SQL.Result(groupedBy.expression, alias: "groupBy"))
+            .sorted(by: groupedBy)
+        self.init(sql)
     }
 }

--- a/Source/ProjectedQuery.swift
+++ b/Source/ProjectedQuery.swift
@@ -1,10 +1,17 @@
 import Foundation
 import Schemata
 
+/// A `Query` that will select the columns required for `Projection` and also handle grouping.
 internal struct ProjectedQuery<Group: ModelValue, Projection: PersistDB.ModelProjection> {
+    /// The projected SQL query, adjusted from what's passed into `init`.
     let sql: SQL.Query
+    
+    /// A mapping of UUIDs to key paths.
+    ///
+    /// UUIDs serve as names for the key paths since the paths aren't convertible to strings.
     let keyPaths: [UUID: PartialKeyPath<Projection.Model>]
 
+    /// Create a new projected query from a SQL query.
     fileprivate init(_ sql: SQL.Query) {
         let projection = Projection.projection
 
@@ -25,6 +32,7 @@ internal struct ProjectedQuery<Group: ModelValue, Projection: PersistDB.ModelPro
         )
     }
 
+    /// Create a result set from the `Row`s returned from the query.
     func resultSet(for rows: [Row]) -> ResultSet<Group, Projection> {
         let projection = Projection.projection
         let groups = rows
@@ -46,6 +54,7 @@ internal struct ProjectedQuery<Group: ModelValue, Projection: PersistDB.ModelPro
         return ResultSet(groups)
     }
 
+    /// Extract the values for each key path in the projection.
     func values(for row: Row) -> [PartialKeyPath<Projection.Model>: SQL.Value] {
         return Dictionary(uniqueKeysWithValues: row.dictionary.flatMap { alias, value in
             guard let uuid = UUID(uuidString: alias), let keyPath = keyPaths[uuid] else {


### PR DESCRIPTION
This shares code between the grouped and ungrouped `fetch` methods and will make it easier to add a grouped version of `observe`.

Tests are still needed for `ProjectedQuery`, but that can be handled separately.