### PR TITLE
Introduce Generator for generating values

### DIFF
--- a/PersistDB.xcodeproj/project.pbxproj
+++ b/PersistDB.xcodeproj/project.pbxproj
@@ -132,6 +132,10 @@
 		BEDE90CB201625A0004656FC /* Table.swift in Sources */ = {isa = PBXBuildFile; fileRef = BEBC36D7201246C1000E3AAB /* Table.swift */; };
 		BEDE90CC201625A1004656FC /* TableTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = BEBC36D5201246B4000E3AAB /* TableTests.swift */; };
 		BEDE90CD201625A2004656FC /* TableTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = BEBC36D5201246B4000E3AAB /* TableTests.swift */; };
+		BEE76A6D202E24F6007A48DB /* Generator.swift in Sources */ = {isa = PBXBuildFile; fileRef = BEE76A6C202E24F6007A48DB /* Generator.swift */; };
+		BEE76A6E202E24F6007A48DB /* Generator.swift in Sources */ = {isa = PBXBuildFile; fileRef = BEE76A6C202E24F6007A48DB /* Generator.swift */; };
+		BEE76A70202E2CEA007A48DB /* GeneratorTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = BEE76A6F202E2CEA007A48DB /* GeneratorTests.swift */; };
+		BEE76A71202E2CEA007A48DB /* GeneratorTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = BEE76A6F202E2CEA007A48DB /* GeneratorTests.swift */; };
 		BEFD30BB1EDEF6B8004FF8FB /* StoreTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = BEFD30BA1EDEF6B8004FF8FB /* StoreTests.swift */; };
 /* End PBXBuildFile section */
 
@@ -227,6 +231,8 @@
 		BEDE90C620160656004656FC /* ReactiveSwift.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; path = ReactiveSwift.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		BEDE90C720160656004656FC /* Result.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; path = Result.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		BEDE90C820160656004656FC /* Schemata.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; path = Schemata.framework; sourceTree = BUILT_PRODUCTS_DIR; };
+		BEE76A6C202E24F6007A48DB /* Generator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Generator.swift; sourceTree = "<group>"; };
+		BEE76A6F202E2CEA007A48DB /* GeneratorTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GeneratorTests.swift; sourceTree = "<group>"; };
 		BEFD30BA1EDEF6B8004FF8FB /* StoreTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = StoreTests.swift; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
@@ -343,6 +349,7 @@
 				BECC0E2220260C10006A1781 /* Day.swift */,
 				BE10ED831FE60763008FFE25 /* Delete.swift */,
 				BEA083D41F3FE92B002AB2C1 /* Expression.swift */,
+				BEE76A6C202E24F6007A48DB /* Generator.swift */,
 				BEBC36C5200AE21B000E3AAB /* Group.swift */,
 				BE10ED721FE198F9008FFE25 /* Insert.swift */,
 				BECF33921EEBA6A600F9FC88 /* Model.swift */,
@@ -371,6 +378,7 @@
 				BECC0E2520260C4E006A1781 /* DayTests.swift */,
 				BEA083D61F3FE977002AB2C1 /* ExpressionTests.swift */,
 				BE1DC60C1EE3BABE00A0671F /* Fixtures.swift */,
+				BEE76A6F202E2CEA007A48DB /* GeneratorTests.swift */,
 				BECF33941EEBA6BA00F9FC88 /* ModelTests.swift */,
 				BE1DC6091EE3B37600A0671F /* PredicateTests.swift */,
 				BE1DC6051EE3ACC600A0671F /* QueryTests.swift */,
@@ -694,6 +702,7 @@
 				BE7361021FD5A01500B675B4 /* Database.swift in Sources */,
 				BECF33931EEBA6A600F9FC88 /* Model.swift in Sources */,
 				BECC0E2320260C10006A1781 /* Day.swift in Sources */,
+				BEE76A6D202E24F6007A48DB /* Generator.swift in Sources */,
 				BE7740E71EFFDC5500D1F5A5 /* SQL.Expression.swift in Sources */,
 				BEA031261FF976DD003C2E90 /* SQL.Value.swift in Sources */,
 				BE1B3E6F1FF1E78F001620A9 /* ProjectedQuery.swift in Sources */,
@@ -726,6 +735,7 @@
 				BE1DC60D1EE3BABE00A0671F /* Fixtures.swift in Sources */,
 				BE7740E21EFFDC4E00D1F5A5 /* SQL.ExpressionTests.swift in Sources */,
 				BE7740E61EFFDC4E00D1F5A5 /* TestDB.swift in Sources */,
+				BEE76A70202E2CEA007A48DB /* GeneratorTests.swift in Sources */,
 				BEDE90CC201625A1004656FC /* TableTests.swift in Sources */,
 				BE10ED7C1FE2FB2E008FFE25 /* SQL.UpdateTests.swift in Sources */,
 			);
@@ -762,6 +772,7 @@
 				BEDE90A2201605AE004656FC /* SQL.Ordering.swift in Sources */,
 				BEDE90AB201605AE004656FC /* Expression.swift in Sources */,
 				BECC0E2420260C10006A1781 /* Day.swift in Sources */,
+				BEE76A6E202E24F6007A48DB /* Generator.swift in Sources */,
 				BEDE909B201605AE004656FC /* Schemata.swift in Sources */,
 				BEDE909F201605AE004656FC /* SQL.Effect.swift in Sources */,
 				BEDE90A4201605AE004656FC /* SQL.Schema.swift in Sources */,
@@ -794,6 +805,7 @@
 				BEDE908A2016059F004656FC /* SQL.QueryTests.swift in Sources */,
 				BEDE90C920160691004656FC /* TestDB.swift in Sources */,
 				BEDE90892016059F004656FC /* SQL.ExpressionTests.swift in Sources */,
+				BEE76A71202E2CEA007A48DB /* GeneratorTests.swift in Sources */,
 				BEDE90CD201625A2004656FC /* TableTests.swift in Sources */,
 				BEDE90972016059F004656FC /* TestStoreTests.swift in Sources */,
 			);

--- a/Source/Delete.swift
+++ b/Source/Delete.swift
@@ -20,7 +20,7 @@ extension Delete {
     internal func makeSQL() -> SQL.Delete {
         return SQL.Delete(
             table: SQL.Table(Model.schema.name),
-            predicate: predicate?.expression.makeSQL()
+            predicate: predicate?.expression.sql
         )
     }
 }

--- a/Source/Expression.swift
+++ b/Source/Expression.swift
@@ -253,7 +253,7 @@ extension SQL {
     }
 }
 
-private func sql(for properties: [AnyProperty]) -> SQL.Expression {
+private func makeSQL(for properties: [AnyProperty]) -> SQL.Expression {
     func column(for property: AnyProperty) -> SQL.Column {
         return SQL.Table(String(describing: property.model))[property.path]
     }
@@ -277,28 +277,28 @@ private func sql(for properties: [AnyProperty]) -> SQL.Expression {
 }
 
 extension AnyExpression {
-    func makeSQL() -> SQL.Expression {
+    var sql: SQL.Expression {
         switch self {
         case let .binary(.equal, .value(.null), rhs):
-            return .binary(.is, rhs.makeSQL(), .value(.null))
+            return .binary(.is, rhs.sql, .value(.null))
         case let .binary(.equal, lhs, .value(.null)):
-            return .binary(.is, lhs.makeSQL(), .value(.null))
+            return .binary(.is, lhs.sql, .value(.null))
         case let .binary(.notEqual, .value(.null), rhs):
-            return .binary(.isNot, rhs.makeSQL(), .value(.null))
+            return .binary(.isNot, rhs.sql, .value(.null))
         case let .binary(.notEqual, lhs, .value(.null)):
-            return .binary(.isNot, lhs.makeSQL(), .value(.null))
+            return .binary(.isNot, lhs.sql, .value(.null))
         case let .binary(op, lhs, rhs):
-            return .binary(op.sql, lhs.makeSQL(), rhs.makeSQL())
+            return .binary(op.sql, lhs.sql, rhs.sql)
         case let .function(function, args):
-            return .function(function.sql, args.map { $0.makeSQL() })
+            return .function(function.sql, args.map { $0.sql })
         case let .inList(expr, list):
-            return .inList(expr.makeSQL(), Set(list.map { $0.makeSQL() }))
+            return .inList(expr.sql, Set(list.map { $0.sql }))
         case let .keyPath(properties):
-            return sql(for: properties)
+            return makeSQL(for: properties)
         case .now:
             return SQL.now
         case let .unary(op, expr):
-            return .unary(op.sql, expr.makeSQL())
+            return .unary(op.sql, expr.sql)
         case let .value(value):
             return .value(value)
         }

--- a/Source/Generator.swift
+++ b/Source/Generator.swift
@@ -1,0 +1,58 @@
+import Schemata
+
+/// A type-erased generator.
+internal enum AnyGenerator {
+    case uuid
+}
+
+extension AnyGenerator: Hashable {
+    internal var hashValue: Int {
+        switch self {
+        case .uuid:
+            return 1
+        }
+    }
+
+    internal static func == (lhs: AnyGenerator, rhs: AnyGenerator) -> Bool {
+        switch (lhs, rhs) {
+        case (.uuid, .uuid):
+            return true
+        }
+    }
+}
+
+extension AnyGenerator {
+    internal func makeSQL() -> SQL.Value {
+        switch self {
+        case .uuid:
+            return .text(UUID().uuidString)
+        }
+    }
+}
+
+/// A value that describes how to generator a value.
+public struct Generator<Value: ModelValue> {
+    /// The type-erased generator that backs this generator.
+    internal var generator: AnyGenerator
+
+    internal init(_ generator: AnyGenerator) {
+        self.generator = generator
+    }
+}
+
+extension Generator: Hashable {
+    public var hashValue: Int {
+        return generator.hashValue
+    }
+
+    public static func == (lhs: Generator, rhs: Generator) -> Bool {
+        return lhs.generator == rhs.generator
+    }
+}
+
+extension Generator where Value == UUID {
+    /// A generator that creates a new UUID.
+    public static func uuid() -> Generator {
+        return Generator(.uuid)
+    }
+}

--- a/Source/Generator.swift
+++ b/Source/Generator.swift
@@ -1,3 +1,4 @@
+import Foundation
 import Schemata
 
 /// A type-erased generator.

--- a/Source/Insert.swift
+++ b/Source/Insert.swift
@@ -29,16 +29,9 @@ extension Insert: ExpressibleByArrayLiteral {
 
 extension Insert {
     internal func makeSQL() -> SQL.Insert {
-        let table = SQL.Table(Model.schema.name)
-        let values = valueSet
-            .values
-            .map { (keyPath, expr) -> (String, SQL.Expression) in
-                let path = Model.schema.properties[keyPath]!.path
-                return (path, expr.makeSQL())
-            }
         return SQL.Insert(
-            table: table,
-            values: Dictionary(uniqueKeysWithValues: values)
+            table: SQL.Table(Model.schema.name),
+            values: valueSet.makeSQL()
         )
     }
 }

--- a/Source/Ordering.swift
+++ b/Source/Ordering.swift
@@ -25,7 +25,7 @@ extension Ordering: Hashable {
 }
 
 extension Ordering {
-    internal func makeSQL() -> SQL.Ordering {
-        return SQL.Ordering(expression.makeSQL(), ascending ? .ascending : .descending)
+    internal var sql: SQL.Ordering {
+        return SQL.Ordering(expression.sql, ascending ? .ascending : .descending)
     }
 }

--- a/Source/ProjectedQuery.swift
+++ b/Source/ProjectedQuery.swift
@@ -21,7 +21,7 @@ internal struct ProjectedQuery<Group: ModelValue, Projection: PersistDB.ModelPro
 
         let aliases = Dictionary(uniqueKeysWithValues: keyPaths.map { ($1, $0) })
         let results = projection.keyPaths.map { keyPath -> SQL.Result in
-            let sql = AnyExpression(keyPath).makeSQL()
+            let sql = AnyExpression(keyPath).sql
             return SQL.Result(sql, alias: aliases[keyPath]?.uuidString)
         }
 
@@ -67,13 +67,13 @@ internal struct ProjectedQuery<Group: ModelValue, Projection: PersistDB.ModelPro
 
 extension ProjectedQuery where Group == None {
     init(_ query: Query<Projection.Model>) {
-        self.init(query.makeSQL())
+        self.init(query.sql)
     }
 }
 
 extension ProjectedQuery {
     init(_ query: Query<Projection.Model>, groupedBy: SQL.Ordering) {
-        let sql = query.makeSQL()
+        let sql = query.sql
             .select(SQL.Result(groupedBy.expression, alias: "groupBy"))
             .sorted(by: groupedBy)
         self.init(sql)

--- a/Source/Query.swift
+++ b/Source/Query.swift
@@ -32,11 +32,11 @@ extension Query: Hashable {
 }
 
 extension Query {
-    internal func makeSQL() -> SQL.Query {
+    internal var sql: SQL.Query {
         let order = self.order.isEmpty ? Model.defaultOrder : self.order
         return SQL.Query(
-            predicates: predicates.map { $0.expression.makeSQL() },
-            order: order.map { $0.makeSQL() }
+            predicates: predicates.map { $0.expression.sql },
+            order: order.map { $0.sql }
         )
     }
 }

--- a/Source/Store.swift
+++ b/Source/Store.swift
@@ -387,7 +387,7 @@ extension Store {
         ascending: Bool = true
     ) -> SignalProducer<ResultSet<Value, Projection>, NoError> {
         let groupedBy = SQL.Ordering(
-            AnyExpression(keyPath).makeSQL(),
+            AnyExpression(keyPath).sql,
             ascending ? .ascending : .descending
         )
         let projected = ProjectedQuery<Value, Projection>(query, groupedBy: groupedBy)
@@ -414,7 +414,7 @@ extension Store {
         ascending: Bool = true
     ) -> SignalProducer<ResultSet<Value, Projection>, NoError> {
         let groupedBy = SQL.Ordering(
-            AnyExpression(keyPath).makeSQL(),
+            AnyExpression(keyPath).sql,
             ascending ? .ascending : .descending
         )
         let projected = ProjectedQuery<Value, Projection>(query, groupedBy: groupedBy)

--- a/Source/TestStore.swift
+++ b/Source/TestStore.swift
@@ -44,8 +44,7 @@ extension Schemata.AnyModel {
 extension Insert {
     fileprivate init(_ id: Model.ID, _ valueSet: ValueSet<Model>) {
         let idValue = AnyExpression.value(Model.ID.anyValue.encode(id).sql)
-        var values = valueSet
-        values.values[Model.idKeyPath] = idValue
+        let values = valueSet.update(with: [ Model.idKeyPath == Expression(idValue) ])
         self.init(unvalidated: values)
     }
 }

--- a/Source/Update.swift
+++ b/Source/Update.swift
@@ -25,7 +25,7 @@ extension Update {
         return SQL.Update(
             table: SQL.Table(Model.schema.name),
             values: valueSet.makeSQL(),
-            predicate: predicate?.expression.makeSQL()
+            predicate: predicate?.expression.sql
         )
     }
 }

--- a/Source/Update.swift
+++ b/Source/Update.swift
@@ -22,16 +22,9 @@ extension Update: Hashable {
 
 extension Update {
     internal func makeSQL() -> SQL.Update {
-        let table = SQL.Table(Model.schema.name)
-        let values = valueSet
-            .values
-            .map { (keyPath, expr) -> (String, SQL.Expression) in
-                let path = Model.schema.properties[keyPath]!.path
-                return (path, expr.makeSQL())
-            }
         return SQL.Update(
-            table: table,
-            values: Dictionary(uniqueKeysWithValues: values),
+            table: SQL.Table(Model.schema.name),
+            values: valueSet.makeSQL(),
             predicate: predicate?.expression.makeSQL()
         )
     }

--- a/Source/ValueSet.swift
+++ b/Source/ValueSet.swift
@@ -33,7 +33,7 @@ extension AnyValue {
     fileprivate func makeSQL() -> SQL.Expression {
         switch self {
         case let .expression(expression):
-            return expression.makeSQL()
+            return expression.sql
         case let .generator(generator):
             return .value(generator.makeSQL())
         }

--- a/Tests/ExpressionTests.swift
+++ b/Tests/ExpressionTests.swift
@@ -1,7 +1,7 @@
 @testable import PersistDB
 import XCTest
 
-class AnyExpressionMakeSQLTest: XCTestCase {
+class AnyExpressionMakeSQLTests: XCTestCase {
     func testNullEquals() {
         let text = SQL.Value.text("foo")
         let expr = AnyExpression.binary(.equal, .value(.null), .value(text))
@@ -57,26 +57,6 @@ class AnyExpressionMakeSQLTest: XCTestCase {
             XCTFail("Wrong primitive: " + String(describing: primitive))
         }
     }
-
-    func testUUID() {
-        let expr = AnyExpression.generator(.uuid)
-
-        let sql1 = expr.makeSQL()
-        let sql2 = expr.makeSQL()
-        XCTAssertNotEqual(sql1, sql2)
-
-        if case let .value(.text(string)) = sql1 {
-            XCTAssertNotNil(UUID(uuidString: string))
-        } else {
-            XCTFail()
-        }
-
-        if case let .value(.text(string)) = sql2 {
-            XCTAssertNotNil(UUID(uuidString: string))
-        } else {
-            XCTFail()
-        }
-    }
 }
 
 class ExpressionInitTests: XCTestCase {
@@ -98,10 +78,5 @@ class ExpressionInitTests: XCTestCase {
     func testDateNow() {
         let expr = Expression<Book, Date>.now
         XCTAssertEqual(expr.expression, .now)
-    }
-
-    func testUUID() {
-        let expr = Expression<Book, UUID>.uuid()
-        XCTAssertEqual(expr.expression, .generator(.uuid))
     }
 }

--- a/Tests/ExpressionTests.swift
+++ b/Tests/ExpressionTests.swift
@@ -1,33 +1,33 @@
 @testable import PersistDB
 import XCTest
 
-class AnyExpressionMakeSQLTests: XCTestCase {
+class AnyExpressionSQLTests: XCTestCase {
     func testNullEquals() {
         let text = SQL.Value.text("foo")
         let expr = AnyExpression.binary(.equal, .value(.null), .value(text))
         let sql = SQL.Expression.binary(.is, .value(text), .value(.null))
-        XCTAssertEqual(expr.makeSQL(), sql)
+        XCTAssertEqual(expr.sql, sql)
     }
 
     func testEqualsNull() {
         let text = SQL.Value.text("foo")
         let expr = AnyExpression.binary(.equal, .value(text), .value(.null))
         let sql = SQL.Expression.binary(.is, .value(text), .value(.null))
-        XCTAssertEqual(expr.makeSQL(), sql)
+        XCTAssertEqual(expr.sql, sql)
     }
 
     func testNullDoesNotEqual() {
         let text = SQL.Value.text("foo")
         let expr = AnyExpression.binary(.notEqual, .value(.null), .value(text))
         let sql = SQL.Expression.binary(.isNot, .value(text), .value(.null))
-        XCTAssertEqual(expr.makeSQL(), sql)
+        XCTAssertEqual(expr.sql, sql)
     }
 
     func testDoesNotEqualNull() {
         let text = SQL.Value.text("foo")
         let expr = AnyExpression.binary(.notEqual, .value(text), .value(.null))
         let sql = SQL.Expression.binary(.isNot, .value(text), .value(.null))
-        XCTAssertEqual(expr.makeSQL(), sql)
+        XCTAssertEqual(expr.sql, sql)
     }
 
     func testKeyPathThatJoins() {
@@ -37,13 +37,13 @@ class AnyExpressionMakeSQLTests: XCTestCase {
             Author.table["id"],
             Author.Table.name
         )
-        XCTAssertEqual(expr.makeSQL(), sql)
+        XCTAssertEqual(expr.sql, sql)
     }
 
     func testNow() {
         let db = TestDB()
         let query = SQL.Query
-            .select([.init(AnyExpression.now.makeSQL(), alias: "now")])
+            .select([.init(AnyExpression.now.sql, alias: "now")])
 
         let before = Date()
         let result = db.query(query)[0]

--- a/Tests/GeneratorTests.swift
+++ b/Tests/GeneratorTests.swift
@@ -1,0 +1,31 @@
+@testable import PersistDB
+import XCTest
+
+class AnyGeneratorMakeSQLTests: XCTestCase {
+    func testUUID() {
+        let generator = AnyGenerator.uuid
+
+        let sql1 = generator.makeSQL()
+        let sql2 = generator.makeSQL()
+        XCTAssertNotEqual(sql1, sql2)
+
+        if case let .text(string) = sql1 {
+            XCTAssertNotNil(UUID(uuidString: string))
+        } else {
+            XCTFail()
+        }
+
+        if case let .text(string) = sql2 {
+            XCTAssertNotNil(UUID(uuidString: string))
+        } else {
+            XCTFail()
+        }
+    }
+}
+
+class GeneratorInitTests: XCTestCase {
+    func testUUID() {
+        let generator = Generator<UUID>.uuid()
+        XCTAssertEqual(generator.generator, .uuid)
+    }
+}

--- a/Tests/UpdateTests.swift
+++ b/Tests/UpdateTests.swift
@@ -15,10 +15,10 @@ class UpdateSQLTests: XCTestCase {
         let sql = SQL.Update(
             table: SQL.Table("Widget"),
             values: [
-                "date": AnyExpression.now.makeSQL(),
+                "date": AnyExpression.now.sql,
                 "double": .value(.real(4.7)),
             ],
-            predicate: predicate.expression.makeSQL()
+            predicate: predicate.expression.sql
         )
         XCTAssertEqual(update.makeSQL(), sql)
     }
@@ -35,7 +35,7 @@ class UpdateSQLTests: XCTestCase {
         let sql = SQL.Update(
             table: SQL.Table("Widget"),
             values: [
-                "date": AnyExpression.now.makeSQL(),
+                "date": AnyExpression.now.sql,
                 "double": .value(.real(4.7)),
             ],
             predicate: nil

--- a/Tests/ValueSetTests.swift
+++ b/Tests/ValueSetTests.swift
@@ -2,33 +2,13 @@
 import XCTest
 
 class ValueSetInitTests: XCTestCase {
-    func testEmpty() {
-        let valueSet = ValueSet<Book>()
-        XCTAssertEqual(valueSet.values, [:])
-    }
-
     func testMultipleAssignmentsWithSameKeyPath() {
         let valueSet: ValueSet<Book> = [
             \.title == "foo",
             \.title == "bar",
         ]
 
-        XCTAssertEqual(valueSet.values, [\Book.title: .value(.text("bar"))])
-    }
-
-    func testMultipleDistinctAssignments() {
-        let valueSet: ValueSet<Author> = [
-            \.born == 1900,
-            \.died == 2000,
-        ]
-
-        XCTAssertEqual(
-            valueSet.values,
-            [
-                \Author.born: .value(.integer(1900)),
-                \Author.died: .value(.integer(2000)),
-            ]
-        )
+        XCTAssertEqual(valueSet, [\Book.title == "bar"])
     }
 }
 


### PR DESCRIPTION
This removes generators from `Expression`, which frees it of side-effects. It also constrains these side-effects to assignments (through `ValueSet`), making `Query` free of side-effects.