### PR TITLE
Move grouping into Query

### DIFF
--- a/Examples/Todo/Source/TaskListViewController.swift
+++ b/Examples/Todo/Source/TaskListViewController.swift
@@ -27,7 +27,7 @@ final class TaskListViewController: UIViewController {
         }
 
         /// The query matching the tasks for the segment.
-        var query: Query<Task> {
+        var query: Query<None, Task> {
             switch self {
             case .all:
                 return Task.all

--- a/Examples/Todo/Tests/TaskTests.swift
+++ b/Examples/Todo/Tests/TaskTests.swift
@@ -1,4 +1,5 @@
 import PersistDB
+import Schemata
 @testable import Todo
 import XCTest
 
@@ -11,7 +12,7 @@ private let later = Date(timeIntervalSinceReferenceDate: 10)
 private let latest = Date(timeIntervalSinceReferenceDate: 1000)
 
 private func AssertMatch(
-    _ query: Query<Task>,
+    _ query: Query<None, Task>,
     _ valueSet: ValueSet<Task>,
     file: StaticString = #file,
     line: UInt = #line
@@ -23,7 +24,7 @@ private func AssertMatch(
 }
 
 private func AssertNoMatch(
-    _ query: Query<Task>,
+    _ query: Query<None, Task>,
     _ valueSet: ValueSet<Task>,
     file: StaticString = #file,
     line: UInt = #line

--- a/PersistDB.xcodeproj/project.pbxproj
+++ b/PersistDB.xcodeproj/project.pbxproj
@@ -64,6 +64,8 @@
 		BEC073ED201D05F800D43F12 /* Swift.swift in Sources */ = {isa = PBXBuildFile; fileRef = BEC073EC201D05F800D43F12 /* Swift.swift */; };
 		BEC073EE201D05F800D43F12 /* Swift.swift in Sources */ = {isa = PBXBuildFile; fileRef = BEC073EC201D05F800D43F12 /* Swift.swift */; };
 		BEC1C2411F1DA64400D29EFF /* SchemataTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = BEC1C2401F1DA64400D29EFF /* SchemataTests.swift */; };
+		BEC77641204B941400221F8A /* Grouping.swift in Sources */ = {isa = PBXBuildFile; fileRef = BEC77640204B941400221F8A /* Grouping.swift */; };
+		BEC77642204B941400221F8A /* Grouping.swift in Sources */ = {isa = PBXBuildFile; fileRef = BEC77640204B941400221F8A /* Grouping.swift */; };
 		BECC0E2320260C10006A1781 /* Day.swift in Sources */ = {isa = PBXBuildFile; fileRef = BECC0E2220260C10006A1781 /* Day.swift */; };
 		BECC0E2420260C10006A1781 /* Day.swift in Sources */ = {isa = PBXBuildFile; fileRef = BECC0E2220260C10006A1781 /* Day.swift */; };
 		BECC0E2620260C4E006A1781 /* DayTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = BECC0E2520260C4E006A1781 /* DayTests.swift */; };
@@ -132,12 +134,12 @@
 		BEDE90CB201625A0004656FC /* Table.swift in Sources */ = {isa = PBXBuildFile; fileRef = BEBC36D7201246C1000E3AAB /* Table.swift */; };
 		BEDE90CC201625A1004656FC /* TableTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = BEBC36D5201246B4000E3AAB /* TableTests.swift */; };
 		BEDE90CD201625A2004656FC /* TableTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = BEBC36D5201246B4000E3AAB /* TableTests.swift */; };
+		BEE76A6A202E0FDE007A48DB /* Action.swift in Sources */ = {isa = PBXBuildFile; fileRef = BEE76A69202E0FDE007A48DB /* Action.swift */; };
+		BEE76A6B202E0FDE007A48DB /* Action.swift in Sources */ = {isa = PBXBuildFile; fileRef = BEE76A69202E0FDE007A48DB /* Action.swift */; };
 		BEE76A6D202E24F6007A48DB /* Generator.swift in Sources */ = {isa = PBXBuildFile; fileRef = BEE76A6C202E24F6007A48DB /* Generator.swift */; };
 		BEE76A6E202E24F6007A48DB /* Generator.swift in Sources */ = {isa = PBXBuildFile; fileRef = BEE76A6C202E24F6007A48DB /* Generator.swift */; };
 		BEE76A70202E2CEA007A48DB /* GeneratorTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = BEE76A6F202E2CEA007A48DB /* GeneratorTests.swift */; };
 		BEE76A71202E2CEA007A48DB /* GeneratorTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = BEE76A6F202E2CEA007A48DB /* GeneratorTests.swift */; };
-		BEE76A6A202E0FDE007A48DB /* Action.swift in Sources */ = {isa = PBXBuildFile; fileRef = BEE76A69202E0FDE007A48DB /* Action.swift */; };
-		BEE76A6B202E0FDE007A48DB /* Action.swift in Sources */ = {isa = PBXBuildFile; fileRef = BEE76A69202E0FDE007A48DB /* Action.swift */; };
 		BEFD30BB1EDEF6B8004FF8FB /* StoreTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = BEFD30BA1EDEF6B8004FF8FB /* StoreTests.swift */; };
 /* End PBXBuildFile section */
 
@@ -220,6 +222,7 @@
 		BEBEB06C1EBEADAA00522152 /* Store.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Store.swift; sourceTree = "<group>"; };
 		BEC073EC201D05F800D43F12 /* Swift.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Swift.swift; sourceTree = "<group>"; };
 		BEC1C2401F1DA64400D29EFF /* SchemataTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SchemataTests.swift; sourceTree = "<group>"; };
+		BEC77640204B941400221F8A /* Grouping.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Grouping.swift; sourceTree = "<group>"; };
 		BECC0E2220260C10006A1781 /* Day.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Day.swift; sourceTree = "<group>"; };
 		BECC0E2520260C4E006A1781 /* DayTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DayTests.swift; sourceTree = "<group>"; };
 		BECF33921EEBA6A600F9FC88 /* Model.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Model.swift; sourceTree = "<group>"; };
@@ -233,9 +236,9 @@
 		BEDE90C620160656004656FC /* ReactiveSwift.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; path = ReactiveSwift.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		BEDE90C720160656004656FC /* Result.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; path = Result.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		BEDE90C820160656004656FC /* Schemata.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; path = Schemata.framework; sourceTree = BUILT_PRODUCTS_DIR; };
+		BEE76A69202E0FDE007A48DB /* Action.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Action.swift; sourceTree = "<group>"; };
 		BEE76A6C202E24F6007A48DB /* Generator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Generator.swift; sourceTree = "<group>"; };
 		BEE76A6F202E2CEA007A48DB /* GeneratorTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GeneratorTests.swift; sourceTree = "<group>"; };
-		BEE76A69202E0FDE007A48DB /* Action.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Action.swift; sourceTree = "<group>"; };
 		BEFD30BA1EDEF6B8004FF8FB /* StoreTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = StoreTests.swift; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
@@ -355,6 +358,7 @@
 				BEA083D41F3FE92B002AB2C1 /* Expression.swift */,
 				BEE76A6C202E24F6007A48DB /* Generator.swift */,
 				BEBC36C5200AE21B000E3AAB /* Group.swift */,
+				BEC77640204B941400221F8A /* Grouping.swift */,
 				BE10ED721FE198F9008FFE25 /* Insert.swift */,
 				BECF33921EEBA6A600F9FC88 /* Model.swift */,
 				BE5AD1CC1F30AADB0055BF9F /* Ordering.swift */,
@@ -711,6 +715,7 @@
 				BE7740E71EFFDC5500D1F5A5 /* SQL.Expression.swift in Sources */,
 				BEA031261FF976DD003C2E90 /* SQL.Value.swift in Sources */,
 				BE1B3E6F1FF1E78F001620A9 /* ProjectedQuery.swift in Sources */,
+				BEC77641204B941400221F8A /* Grouping.swift in Sources */,
 				BEBC36CD200E8FD8000E3AAB /* Schemata.swift in Sources */,
 				BEA0312B2001842E003C2E90 /* SQL.Effect.swift in Sources */,
 				BE7740ED1EFFDC5500D1F5A5 /* SQL.Table.swift in Sources */,
@@ -782,6 +787,7 @@
 				BEDE909B201605AE004656FC /* Schemata.swift in Sources */,
 				BEDE909F201605AE004656FC /* SQL.Effect.swift in Sources */,
 				BEDE90A4201605AE004656FC /* SQL.Schema.swift in Sources */,
+				BEC77642204B941400221F8A /* Grouping.swift in Sources */,
 				BEDE90A1201605AE004656FC /* SQL.Insert.swift in Sources */,
 				BEDE90A9201605AE004656FC /* Database.swift in Sources */,
 				BEDE909D201605AE004656FC /* SQL.Column.swift in Sources */,

--- a/README.md
+++ b/README.md
@@ -132,7 +132,7 @@ Stores can only be loaded asynchronously so the main thread can’t accidentally
 Sets of objects are fetched with `Query`s, which use `Predicate`s to filter the available models and `SortDescriptor`s to sort them.
 
 ```swift
-let harryPotter: Query<Book> = Book.all
+let harryPotter: Query<None, Book> = Book.all
     .filter(\.author.name == "J.K. Rowling")
     .sort(by: \.title)
 ```

--- a/Source/Grouping.swift
+++ b/Source/Grouping.swift
@@ -1,0 +1,37 @@
+import Schemata
+
+/// A expression that will be used to group a query.
+public struct Grouping<Model: PersistDB.Model, Key: ModelValue> {
+    /// The underlying expression.
+    public var expression: Expression<Model, Key>
+
+    /// Whether the groups should be sorted ascending or descending.
+    public var ascending: Bool
+
+    public init(_ expression: Expression<Model, Key>, ascending: Bool = true) {
+        self.expression = expression
+        self.ascending = ascending
+    }
+}
+
+extension Grouping: Hashable {
+    public var hashValue: Int {
+        return expression.hashValue
+    }
+
+    public static func == (lhs: Grouping, rhs: Grouping) -> Bool {
+        return lhs.expression == rhs.expression && lhs.ascending == rhs.ascending
+    }
+}
+
+extension Grouping where Key == None {
+    static var none: Grouping {
+        return Grouping(Expression(.value(.null)))
+    }
+}
+
+extension Grouping {
+    var sql: SQL.Ordering {
+        return Ordering<Model>(expression.expression, ascending: ascending).sql
+    }
+}

--- a/Source/Model.swift
+++ b/Source/Model.swift
@@ -11,7 +11,7 @@ public protocol Model: Schemata.Model {
 
 extension Model {
     /// A `Query` matching all values.
-    public static var all: Query<Self> {
+    public static var all: Query<None, Self> {
         return .init()
     }
 }

--- a/Source/Store.swift
+++ b/Source/Store.swift
@@ -351,10 +351,10 @@ extension Store {
     /// - returns: A `SignalProducer` that will fetch projections for entities that match the query.
     ///
     /// - important: Nothing will be done until the returned producer is started.
-    public func fetch<Projection: ModelProjection>(
-        _ query: Query<Projection.Model>
-    ) -> SignalProducer<ResultSet<None, Projection>, NoError> {
-        let projected = ProjectedQuery<None, Projection>(query)
+    public func fetch<Key, Projection: ModelProjection>(
+        _ query: Query<Key, Projection.Model>
+    ) -> SignalProducer<ResultSet<Key, Projection>, NoError> {
+        let projected = ProjectedQuery<Key, Projection>(query)
         return fetch(projected)
     }
 
@@ -370,62 +370,10 @@ extension Store {
     ////           query, sending a new set whenever it's changed.
     ///
     /// - important: Nothing will be done until the returned producer is started.
-    public func observe<Projection: ModelProjection>(
-        _ query: Query<Projection.Model>
-    ) -> SignalProducer<ResultSet<None, Projection>, NoError> {
-        let projected = ProjectedQuery<None, Projection>(query)
-        return observe(projected)
-    }
-
-    /// Fetch projections from the store with a query and group them by some value.
-    ///
-    /// - parameters:
-    ///   - query: A query matching the model entities to be projected.
-    ///   - keyPath: The property that should be used to group consecutive projections.
-    ///   - ascending: Whether the query should be sorted by the `keyPath` ascending or descending.
-    ///
-    /// - returns: A `SignalProducer` that will fetch projections for entities that match the query.
-    ///
-    /// - important: Nothing will be done until the returned producer is started.
-    ///
-    /// - important: This will sort the query by the grouped property.
-    public func fetch<Projection: ModelProjection, Value: ModelValue>(
-        _ query: Query<Projection.Model>,
-        groupedBy keyPath: KeyPath<Projection.Model, Value>,
-        ascending: Bool = true
-    ) -> SignalProducer<ResultSet<Value, Projection>, NoError> {
-        let groupedBy = SQL.Ordering(
-            AnyExpression(keyPath).sql,
-            ascending ? .ascending : .descending
-        )
-        let projected = ProjectedQuery<Value, Projection>(query, groupedBy: groupedBy)
-        return fetch(projected)
-    }
-
-    /// Observe projections from the store with a query that have been grouped by some value.
-    ///
-    /// When `insert`, `delete`, or `update` is called that *might* affect the result, the
-    /// projections will be re-fetched and re-sent.
-    ///
-    /// - parameters:
-    ///   - query: A query matching the model entities to be projected.
-    ///   - keyPath: The property that should be used to group consecutive projections.
-    ///   - ascending: Whether the query should be sorted by the `keyPath` ascending or descending.
-    ///
-    /// - returns: A `SignalProducer` that will send sets of projections for entities that match the
-    ////           query, sending a new set whenever it's changed.
-    ///
-    /// - important: Nothing will be done until the returned producer is started.
-    public func observe<Projection: ModelProjection, Value: ModelValue>(
-        _ query: Query<Projection.Model>,
-        groupedBy keyPath: KeyPath<Projection.Model, Value>,
-        ascending: Bool = true
-    ) -> SignalProducer<ResultSet<Value, Projection>, NoError> {
-        let groupedBy = SQL.Ordering(
-            AnyExpression(keyPath).sql,
-            ascending ? .ascending : .descending
-        )
-        let projected = ProjectedQuery<Value, Projection>(query, groupedBy: groupedBy)
+    public func observe<Key, Projection: ModelProjection>(
+        _ query: Query<Key, Projection.Model>
+    ) -> SignalProducer<ResultSet<Key, Projection>, NoError> {
+        let projected = ProjectedQuery<Key, Projection>(query)
         return observe(projected)
     }
 }

--- a/Source/TestStore.swift
+++ b/Source/TestStore.swift
@@ -82,7 +82,7 @@ public final class TestStore {
 
     /// Synchronously fetch the results of the query.
     public func fetch<Model>(
-        _ query: Query<Model>
+        _ query: Query<None, Model>
     ) -> [Model.ID] {
         return store
             .fetch(query)
@@ -93,7 +93,7 @@ public final class TestStore {
 
     /// Synchronously fetch the results of the query.
     public func fetch<Projection: ModelProjection>(
-        _ query: Query<Projection.Model>
+        _ query: Query<None, Projection.Model>
     ) -> [Projection] {
         return store
             .fetch(query)


### PR DESCRIPTION
This cuts down on overloads in `Store` and increases symmetry between `Query` and `ResultSet`.