### PR TITLE
Group Query by arbitrary Expressions

### DIFF
--- a/Source/Expression.swift
+++ b/Source/Expression.swift
@@ -312,6 +312,11 @@ public struct Expression<Model: PersistDB.Model, Value> {
     internal init(_ expression: AnyExpression) {
         self.expression = expression
     }
+
+    /// Create an expression from a keypath.
+    public init(_ keyPath: KeyPath<Model, Value>) {
+        expression = AnyExpression(keyPath)
+    }
 }
 
 extension Expression: Hashable {

--- a/Source/Expression.swift
+++ b/Source/Expression.swift
@@ -28,6 +28,7 @@ internal indirect enum AnyExpression {
 
     internal enum Function {
         case coalesce
+        case length
         case max
         case min
     }
@@ -133,16 +134,19 @@ extension AnyExpression.Function: Hashable {
         switch self {
         case .coalesce:
             return 1
-        case .max:
+        case .length:
             return 2
-        case .min:
+        case .max:
             return 3
+        case .min:
+            return 4
         }
     }
 
     static func == (lhs: AnyExpression.Function, rhs: AnyExpression.Function) -> Bool {
         switch (lhs, rhs) {
         case (.coalesce, .coalesce),
+             (.length, .length),
              (.max, .max),
              (.min, .min):
             return true
@@ -171,6 +175,8 @@ extension AnyExpression.Function {
         switch self {
         case .coalesce:
             return .coalesce
+        case .length:
+            return .length
         case .max:
             return .max
         case .min:
@@ -345,6 +351,13 @@ extension Expression where Value: ModelValue {
 extension Expression where Value: OptionalProtocol, Value.Wrapped: ModelValue {
     public init(_ value: Value?) {
         expression = .value(value.map(Value.Wrapped.anyValue.encode)?.sql ?? .null)
+    }
+}
+
+extension Expression where Value == String {
+    /// The number of characters in the string prior to the first null character.
+    public var count: Expression<Model, Int> {
+        return Expression<Model, Int>(.function(.length, [ expression ]))
     }
 }
 

--- a/Source/Query.swift
+++ b/Source/Query.swift
@@ -61,10 +61,18 @@ extension Query {
         by keyPath: KeyPath<Model, Value>,
         ascending: Bool = true
     ) -> Query<Value, Model> {
+        return group(by: Expression(AnyExpression(keyPath)), ascending: ascending)
+    }
+
+    /// Returns a query that is grouped by the given expression.
+    public func group<Value>(
+        by expression: Expression<Model, Value>,
+        ascending: Bool = true
+    ) -> Query<Value, Model> {
         return Query<Value, Model>(
             predicates: predicates,
             order: order,
-            groupedBy: Grouping(Expression(AnyExpression(keyPath)), ascending: ascending)
+            groupedBy: Grouping(expression, ascending: ascending)
         )
     }
 

--- a/Source/SQL/SQL.Expression.swift
+++ b/Source/SQL/SQL.Expression.swift
@@ -23,6 +23,7 @@ extension SQL {
 
     internal enum Function: String {
         case coalesce = "COALESCE"
+        case length = "LENGTH"
         case max = "MAX"
         case min = "MIN"
         case strftime = "STRFTIME"

--- a/Tests/StoreTests.swift
+++ b/Tests/StoreTests.swift
@@ -196,6 +196,27 @@ class StoreFetchGroupedByTests: StoreTests {
         let actual = fetchGrouped(Author.all.sort(by: \.name).group(by: \.born))
         XCTAssertEqual(actual, expected)
     }
+
+    func testGroupByExpression() {
+        insert(.orsonScottCard, .jrrTolkien, .isaacAsimov, .rayBradbury)
+
+        let expected = ResultSet<Int, AuthorName>([
+            Group(
+                key: 12,
+                values: [ AuthorName(.isaacAsimov), AuthorName(.rayBradbury) ]
+            ),
+            Group(
+                key: 14,
+                values: [ AuthorName(.jrrTolkien) ]
+            ),
+            Group(
+                key: 16,
+                values: [ AuthorName(.orsonScottCard) ]
+            ),
+        ])
+        let actual = fetchGrouped(Author.all.group(by: Expression(\Author.name).count))
+        XCTAssertEqual(actual, expected)
+    }
 }
 
 class StoreInsertTests: StoreTests {


### PR DESCRIPTION
Bonus:
- Create `Expression`s for `KeyPath`s
- `Expression<_, String>.count`