### PR TITLE
Add support for app groups

### DIFF
--- a/Source/Store.swift
+++ b/Source/Store.swift
@@ -192,6 +192,58 @@ public final class Store {
     ) -> SignalProducer<Store, OpenError> {
         return open(libraryNamed: fileName, for: types.map { $0.anySchema })
     }
+
+    /// Open an on-disk store inside the application group directory.
+    ///
+    /// - parameters:
+    ///   - fileName: The name of the file within the Application Support directory to use for the
+    ///               store.
+    ///   - applicationGroup: The identifier for the shared application group.
+    ///   - schemas: The schemas for the models in the store.
+    ///
+    /// - returns: A `SignalProducer` that will create and send a `Store` or send an `OpenError` if
+    ///            one couldn't be opened.
+    ///
+    /// - important: Nothing will be done until the returned producer is started.
+    ///
+    /// This will create a store at that URL if one doesn't already exist.
+    public static func open(
+        libraryNamed fileName: String,
+        inApplicationGroup applicationGroup: String,
+        for schemas: [AnySchema]
+    ) -> SignalProducer<Store, OpenError> {
+        let url = FileManager
+            .default
+            .containerURL(forSecurityApplicationGroupIdentifier: applicationGroup)!
+            .appendingPathComponent(fileName)
+        return open(at: url, for: schemas)
+    }
+
+    /// Open an on-disk store inside the application group directory.
+    ///
+    /// - parameters:
+    ///   - fileName: The name of the file within the Application Support directory to use for the
+    ///               store.
+    ///   - applicationGroup: The identifier for the shared application group.
+    ///   - types: The model types in the store.
+    ///
+    /// - returns: A `SignalProducer` that will create and send a `Store` or send an `OpenError` if
+    ///            one couldn't be opened.
+    ///
+    /// - important: Nothing will be done until the returned producer is started.
+    ///
+    /// This will create a store at that URL if one doesn't already exist.
+    public static func open(
+        libraryNamed fileName: String,
+        inApplicationGroup applicationGroup: String,
+        for types: [Schemata.AnyModel.Type]
+    ) -> SignalProducer<Store, OpenError> {
+        return open(
+            libraryNamed: fileName,
+            inApplicationGroup: applicationGroup,
+            for: types.map { $0.anySchema }
+        )
+    }
 }
 
 extension Store {

--- a/Tests/SQL/SQL.QueryTests.swift
+++ b/Tests/SQL/SQL.QueryTests.swift
@@ -311,11 +311,7 @@ class SQLQueryJoinTests: SQLQueryTests {
         )
         let query = SQL.Query
             .select(Book.Table.allColumns)
-            .sorted(
-                by:
-                    join.ascending,
-                Book.Table.title.ascending
-            )
+            .sorted(by: join.ascending, Book.Table.title.ascending)
 
         XCTAssertEqual(query, query)
         XCTAssertEqual(
@@ -431,11 +427,7 @@ class SQLQuerySortedByTests: SQLQueryTests {
         let query = SQL.Query
             .select(Book.Table.allColumns)
             .where(.binary(.equal, Book.Table.author, Author.Table.id))
-            .sorted(
-                by:
-                    Author.Table.name.ascending,
-                Book.Table.title.ascending
-            )
+            .sorted(by: Author.Table.name.ascending, Book.Table.title.ascending)
         XCTAssertEqual(query, query)
         XCTAssertEqual(
             db.query(query),


### PR DESCRIPTION
This includes observing changes from other processes from within the app group.

Unfortunately:

1. This is pretty much untestable AFAIK
2. The notifications force all observations to reload

(2) should be addressed by planned log/sync functionality in the future.